### PR TITLE
Fix qtweetlib with qt 4.8

### DIFF
--- a/src/oauthtwitter.cpp
+++ b/src/oauthtwitter.cpp
@@ -136,6 +136,7 @@ void OAuthTwitter::authorizePin()
 
     QNetworkRequest req(url);
     req.setRawHeader(AUTH_HEADER, oauthHeader);
+    req.setHeader(QNetworkRequest::ContentTypeHeader, "application/x-www-form-urlencoded");
 
     //enters event loop, simulate blocking io
     QEventLoop q;
@@ -201,6 +202,7 @@ void OAuthTwitter::requestAccessToken(int pin)
 
     QNetworkRequest req(url);
     req.setRawHeader(AUTH_HEADER, oauthHeader);
+    req.setHeader(QNetworkRequest::ContentTypeHeader, "application/x-www-form-urlencoded");
 
     QNetworkReply *reply = m_netManager->post(req, QByteArray());
     connect(reply, SIGNAL(finished()), &q, SLOT(quit()));

--- a/src/qtweetblockscreate.cpp
+++ b/src/qtweetblockscreate.cpp
@@ -68,6 +68,7 @@ void QTweetBlocksCreate::create(qint64 userid, bool includeEntities)
 
     QByteArray oauthHeader = oauthTwitter()->generateAuthorizationHeader(urlQuery, OAuth::POST);
     req.setRawHeader(AUTH_HEADER, oauthHeader);
+    req.setHeader(QNetworkRequest::ContentTypeHeader, "application/x-www-form-urlencoded");
 
     QByteArray postBody = urlQuery.toEncoded(QUrl::RemoveScheme | QUrl::RemoveAuthority | QUrl::RemovePath);
     postBody.remove(0, 1);
@@ -101,6 +102,7 @@ void QTweetBlocksCreate::create(const QString& screenName, bool includeEntities)
 
     QByteArray oauthHeader = oauthTwitter()->generateAuthorizationHeader(urlQuery, OAuth::POST);
     req.setRawHeader(AUTH_HEADER, oauthHeader);
+    req.setHeader(QNetworkRequest::ContentTypeHeader, "application/x-www-form-urlencoded");
 
     QByteArray postBody = urlQuery.toEncoded(QUrl::RemoveScheme | QUrl::RemoveAuthority | QUrl::RemovePath);
     postBody.remove(0, 1);

--- a/src/qtweetdirectmessagenew.cpp
+++ b/src/qtweetdirectmessagenew.cpp
@@ -107,6 +107,7 @@ void QTweetDirectMessageNew::post(const QString &screenName, const QString &text
 
     QByteArray oauthHeader = oauthTwitter()->generateAuthorizationHeader(urlQuery, OAuth::POST);
     req.setRawHeader(AUTH_HEADER, oauthHeader);
+    req.setHeader(QNetworkRequest::ContentTypeHeader, "application/x-www-form-urlencoded");
 
     QByteArray postBody = urlQuery.toEncoded(QUrl::RemoveScheme | QUrl::RemoveAuthority | QUrl::RemovePath);
     postBody.remove(0, 1);

--- a/src/qtweetfavoritescreate.cpp
+++ b/src/qtweetfavoritescreate.cpp
@@ -64,6 +64,7 @@ void QTweetFavoritesCreate::create(qint64 statusid, bool includeEntities)
 
     QByteArray oauthHeader = oauthTwitter()->generateAuthorizationHeader(url, OAuth::POST);
     req.setRawHeader(AUTH_HEADER, oauthHeader);
+    req.setHeader(QNetworkRequest::ContentTypeHeader, "application/x-www-form-urlencoded");
 
     QNetworkReply *reply = oauthTwitter()->networkAccessManager()->post(req, QByteArray());
     connect(reply, SIGNAL(finished()), this, SLOT(reply()));

--- a/src/qtweetfriendshipcreate.cpp
+++ b/src/qtweetfriendshipcreate.cpp
@@ -74,6 +74,7 @@ void QTweetFriendshipCreate::create(qint64 userid,
 
     QByteArray oauthHeader = oauthTwitter()->generateAuthorizationHeader(urlQuery, OAuth::POST);
     req.setRawHeader(AUTH_HEADER, oauthHeader);
+    req.setHeader(QNetworkRequest::ContentTypeHeader, "application/x-www-form-urlencoded");
 
     QByteArray postBody = urlQuery.toEncoded(QUrl::RemoveScheme | QUrl::RemoveAuthority | QUrl::RemovePath);
     postBody.remove(0, 1);
@@ -113,6 +114,7 @@ void QTweetFriendshipCreate::create(const QString &screenName,
 
     QByteArray oauthHeader = oauthTwitter()->generateAuthorizationHeader(urlQuery, OAuth::POST);
     req.setRawHeader(AUTH_HEADER, oauthHeader);
+    req.setHeader(QNetworkRequest::ContentTypeHeader, "application/x-www-form-urlencoded");
 
     QByteArray postBody = urlQuery.toEncoded(QUrl::RemoveScheme | QUrl::RemoveAuthority | QUrl::RemovePath);
     postBody.remove(0, 1);

--- a/src/qtweetgeoplacecreate.cpp
+++ b/src/qtweetgeoplacecreate.cpp
@@ -74,6 +74,7 @@ void QTweetGeoPlaceCreate::create(const QString &name,
 
     QNetworkRequest req(url);
     req.setRawHeader(AUTH_HEADER, oauthHeader);
+    req.setHeader(QNetworkRequest::ContentTypeHeader, "application/x-www-form-urlencoded");
 
     QByteArray statusPost = urlQuery.toEncoded(QUrl::RemoveScheme | QUrl::RemoveAuthority | QUrl::RemovePath);
     statusPost.remove(0, 1);

--- a/src/qtweetlistaddmember.cpp
+++ b/src/qtweetlistaddmember.cpp
@@ -55,6 +55,7 @@ void QTweetListAddMember::add(qint64 user, qint64 list, qint64 memberid)
 
     QByteArray oauthHeader = oauthTwitter()->generateAuthorizationHeader(url, OAuth::POST);
     req.setRawHeader(AUTH_HEADER, oauthHeader);
+    req.setHeader(QNetworkRequest::ContentTypeHeader, "application/x-www-form-urlencoded");
 
     QNetworkReply *reply = oauthTwitter()->networkAccessManager()->post(req, QByteArray());
     connect(reply, SIGNAL(finished()), this, SLOT(reply()));

--- a/src/qtweetlistcreate.cpp
+++ b/src/qtweetlistcreate.cpp
@@ -69,6 +69,7 @@ void QTweetListCreate::create(qint64 user,
 
     QByteArray oauthHeader = oauthTwitter()->generateAuthorizationHeader(urlQuery, OAuth::POST);
     req.setRawHeader(AUTH_HEADER, oauthHeader);
+    req.setHeader(QNetworkRequest::ContentTypeHeader, "application/x-www-form-urlencoded");
 
     QByteArray postBody = urlQuery.toEncoded(QUrl::RemoveScheme | QUrl::RemoveAuthority | QUrl::RemovePath);
     postBody.remove(0, 1);

--- a/src/qtweetlistsubscribe.cpp
+++ b/src/qtweetlistsubscribe.cpp
@@ -52,6 +52,7 @@ void QTweetListSubscribe::follow(qint64 user, qint64 list)
 
     QByteArray oauthHeader = oauthTwitter()->generateAuthorizationHeader(url, OAuth::POST);
     req.setRawHeader(AUTH_HEADER, oauthHeader);
+    req.setHeader(QNetworkRequest::ContentTypeHeader, "application/x-www-form-urlencoded");
 
     QNetworkReply *reply = oauthTwitter()->networkAccessManager()->post(req, QByteArray());
     connect(reply, SIGNAL(finished()), this, SLOT(reply()));

--- a/src/qtweetlistupdate.cpp
+++ b/src/qtweetlistupdate.cpp
@@ -70,6 +70,7 @@ void QTweetListUpdate::update(qint64 user,
 
     QByteArray oauthHeader = oauthTwitter()->generateAuthorizationHeader(urlQuery, OAuth::POST);
     req.setRawHeader(AUTH_HEADER, oauthHeader);
+    req.setHeader(QNetworkRequest::ContentTypeHeader, "application/x-www-form-urlencoded");
 
     QByteArray postBody = urlQuery.toEncoded(QUrl::RemoveScheme | QUrl::RemoveAuthority | QUrl::RemovePath);
     postBody.remove(0, 1);

--- a/src/qtweetstatusdestroy.cpp
+++ b/src/qtweetstatusdestroy.cpp
@@ -66,6 +66,7 @@ void QTweetStatusDestroy::destroy(qint64 id,
 
     QByteArray oauthHeader = oauthTwitter()->generateAuthorizationHeader(urlQuery, OAuth::POST);
     req.setRawHeader(AUTH_HEADER, oauthHeader);
+    req.setHeader(QNetworkRequest::ContentTypeHeader, "application/x-www-form-urlencoded");
 
     QByteArray postBody = urlQuery.toEncoded(QUrl::RemoveScheme | QUrl::RemoveAuthority | QUrl::RemovePath);
     postBody.remove(0, 1);

--- a/src/qtweetstatusretweet.cpp
+++ b/src/qtweetstatusretweet.cpp
@@ -54,6 +54,7 @@ void QTweetStatusRetweet::retweet(qint64 id,
         url.addQueryItem("include_entities", "true");
 
     QNetworkRequest req(url);
+    req.setHeader(QNetworkRequest::ContentTypeHeader, "application/x-www-form-urlencoded");
 
     if (isAuthenticationEnabled()) {    //Oh, Twitter API docs wrong?
         QByteArray oauthHeader = oauthTwitter()->generateAuthorizationHeader(url, OAuth::POST);

--- a/src/qtweetstatusupdate.cpp
+++ b/src/qtweetstatusupdate.cpp
@@ -86,6 +86,7 @@ void QTweetStatusUpdate::post(const QString &status,
     QByteArray oauthHeader = oauthTwitter()->generateAuthorizationHeader(urlQuery, OAuth::POST);
     QNetworkRequest req(url);
     req.setRawHeader(AUTH_HEADER, oauthHeader);
+    req.setHeader(QNetworkRequest::ContentTypeHeader, "application/x-www-form-urlencoded");
 
     //build status post array
     QByteArray statusPost = urlQuery.toEncoded(QUrl::RemoveScheme | QUrl::RemoveAuthority | QUrl::RemovePath);


### PR DESCRIPTION
Qt used to default to "application/x-www-form-urlencoded" as the content-type of POST requests in pre-4.8, but in 4.8 the default changed.
